### PR TITLE
RED-73714 fixing Fixture before always pass and more logs

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -20,7 +20,6 @@ class API {
         });
         this._debug = debug || false;
     }
-
     /**
      * Checking the connection to the report portal server
      */
@@ -45,8 +44,8 @@ class API {
     async createLaunch(projectName, options) {
         if (this._debug == true) {
             process.stdout
-                .write(`[${filename}] createLaunch:post /${projectName}/launch\n 
-                with options: ${JSON.stringify(options)}`);
+                .write(`[${filename}] createLaunch: [POST] /${projectName}/launch 
+                with options: ${JSON.stringify(options)}\n`);
         }
         try {
             return this.handleResponse(
@@ -56,24 +55,26 @@ class API {
             return this.handleError(error);
         }
     }
+    /**
+     * Getting launch attributes
+     * @param {*} projectName The name of the project
+     * @param {*} launchId The id of the launch
+     */
+    async getLaunchAttributes(projectName, launchId) {
+        if (this._debug == true)
+            process.stdout.write(
+                `[${filename}] getLaunchAttributes: [GET] ${projectName}/launch/${launchId}\n`
+            );
 
-
-   /**
-   * Getting launch attributes
-   * @param {*} projectName The name of the project
-   * @param {*} launchId The id of the launch
-   */
-  async getLaunchAttributes(projectName, launchId) {
-    if (this._debug == true) process.stdout.write(`[${filename}] getting launch attributes: ${projectName}/launch/${launchId}\n`);
-
-    try {
-      const res = await this.handleResponse(await this.client.get(`/${projectName}/launch/uuid/${launchId}`));
-      return res.attributes;
-    } catch (error) {
-      return this.handleError(error);
+        try {
+            const res = await this.handleResponse(
+                await this.client.get(`/${projectName}/launch/uuid/${launchId}`)
+            );
+            return res.attributes;
+        } catch (error) {
+            return this.handleError(error);
+        }
     }
-  }
-
     /**
      * Finishing an existing launch
      * @param {*} projectName The name of the project
@@ -84,9 +85,9 @@ class API {
     async finishLaunch(projectName, launchId, options) {
         if (this._debug == true) {
             process.stdout
-                .write(`[${filename}] finishLaunch:put ${projectName}/launch/${launchId}/finish\n 
-                with options: ${JSON.stringify(options)} \n 
-                with launchId: ${JSON.stringify(launchId)}`);
+                .write(`[${filename}] finishLaunch: [PUT] ${projectName}/launch/${launchId}/finish 
+                with options: ${JSON.stringify(options)} 
+                with launchId: ${JSON.stringify(launchId)}\n`);
         }
         try {
             return this.handleResponse(
@@ -109,9 +110,9 @@ class API {
     async forceStopLaunch(projectName, launchId, options) {
         if (this._debug == true) {
             process.stdout
-                .write(`[${filename}]forceStopLaunch:put /launch/${launchId}/stop\n 
-                with options: ${JSON.stringify(options)}\n 
-                with launchId: ${JSON.stringify(launchId)}`);
+                .write(`[${filename}]forceStopLaunch: [PUT] /launch/${launchId}/stop 
+                with options: ${JSON.stringify(options)}
+                with launchId: ${JSON.stringify(launchId)}\n`);
         }
         try {
             return this.handleResponse(
@@ -132,10 +133,10 @@ class API {
 
     async createTestItem(projectName, options) {
         if (this._debug == true) {
-            process.stdout.write(`[${filename}]launch:${
-                options.launchUuid
-            } createTestItem:post  /${projectName}/item\n 
-            with options: ${JSON.stringify(options)}`);
+            process.stdout
+                .write(`[${filename}] createTestItem: [POST]  /${projectName}/item
+            Of launch: ${options.launchUuid}
+            With options: ${JSON.stringify(options)}\n`);
         }
         try {
             return this.handleResponse(
@@ -154,11 +155,11 @@ class API {
 
     async createChildTestItem(projectName, parentItem, options) {
         if (this._debug == true) {
-            process.stdout.write(`[${filename}]launch:${
-                options.launchUuid
-            } createChildTestItem:post /${projectName}/item/${parentItem}\n
-            with options: ${JSON.stringify(options)}\n 
-            time:${this.now()}\n`);
+            process.stdout
+                .write(`[${filename}] createChildTestItem: [POST] /${projectName}/item/${parentItem}
+            Of launch: ${options.launchUuid}
+            With options: ${JSON.stringify(options)}
+            Time:${this.now()}\n`);
         }
         try {
             return this.handleResponse(
@@ -180,10 +181,10 @@ class API {
 
     async finishTestItem(projectName, testItemId, options) {
         if (this._debug == true) {
-            process.stdout.write(`[${filename}]launch:${
-                options.launchUuid
-            } finishTestItem:put /${projectName}/item/${testItemId}\n
-                with options: ${JSON.stringify(options)}\n `);
+            process.stdout;
+            write(`[${filename}] finishTestItem: [PUT] /${projectName}/item/${testItemId}
+            Of launch: ${options.launchUuid}
+            With options: ${JSON.stringify(options)}\n `);
         }
         try {
             return this.handleResponse(
@@ -253,13 +254,18 @@ class API {
     async sendLog(projectName, options) {
         if (options !== undefined) {
             try {
-                if (this._debug == true) {
-                    process.stdout.write(
-                        `[${filename}]enter sendLog under: ${
-                            options.itemUuid
-                        } time:${this.now()}\n`
-                    );
+                if (this._debug == true && options.file === undefined) {
+                    process.stdout
+                        .write(`[POST][${filename}]enter sendLog under itemUuid: ${
+                        options.itemUuid
+                    } 
+                    Time: ${this.now()}
+                    launchUuid: ${options.launchUuid}
+                    Loglevel: ${options.level}
+                    Log-msg: [${options.message}]
+                    Contains file?: [${options.file !== undefined}]\n`);
                 }
+
                 if (typeof options.message !== "string")
                     options.message = `${options.message}`;
 
@@ -267,30 +273,7 @@ class API {
                     options.file !== undefined &&
                     options.file.path !== undefined
                 ) {
-                    const MULTIPART_BOUNDARY = Math.floor(
-                        Math.random() * 10000000000
-                    ).toString();
-                    const fullPath = options.file.path;
-                    const instance = await axios.create({
-                        baseURL: this.baseURL,
-                        headers: {
-                            "Content-type": `multipart/form-data; boundary=${MULTIPART_BOUNDARY}`,
-                            Authorization: `Bearer ${this.token}`,
-                        },
-                    }); //request body
-
-                    await instance.post(
-                        `${this.baseURL}/${projectName}/log`,
-                        this.buildMultiPartStream(
-                            [options],
-                            {
-                                name: options.file.name,
-                                type: "image/png",
-                                content: fs.readFileSync(fullPath),
-                            },
-                            MULTIPART_BOUNDARY
-                        )
-                    );
+                    await this.sendLogWithFile(options, projectName);
                 } else {
                     this.handleResponse(
                         await this.client.post(`/${projectName}/log`, options)
@@ -303,6 +286,44 @@ class API {
                 this.handleError(error);
             }
         }
+    }
+    async sendLogWithFile(options, projectName) {
+        if (this._debug == true) {
+            process.stdout
+                .write(`[POST][${filename}]enter sendLog under itemUuid: ${
+                options.itemUuid
+            } 
+                 time: ${this.now()}
+                 launchUuid: ${options.launchUuid}
+                 loglevel: ${options.level}
+                 log-msg: [${options.message}]
+                 file: [${options.file.path}]]\n`);
+        }
+        const MULTIPART_BOUNDARY = Math.floor(
+            Math.random() * 10000000000
+        ).toString();
+        const fullPath = options.file.path;
+        const instance = await axios.create({
+            baseURL: this.baseURL,
+            headers: {
+                "Content-type": `multipart/form-data; boundary=${MULTIPART_BOUNDARY}`,
+                Authorization: `Bearer ${this.token}`,
+            },
+        }); //request body
+        this.handleResponse(
+            await instance.post(
+                `${this.baseURL}/${projectName}/log`,
+                this.buildMultiPartStream(
+                    [options],
+                    {
+                        name: options.file.name,
+                        type: "image/png",
+                        content: fs.readFileSync(fullPath),
+                    },
+                    MULTIPART_BOUNDARY
+                )
+            )
+        );
     }
     /**
      * Retrieving the timestamp right now
@@ -318,11 +339,14 @@ class API {
 
     handleResponse(response) {
         if (this._debug == true) {
-            process.stdout.write(
-                `\n[${filename}] handle reponse:${JSON.stringify(
-                    response.data
-                )}\n with status: ${response.status}\n`
-            );
+            process.stdout
+                .write(`\n\t>[${filename}] Handle reponse of request[${
+                response.request.path
+            }] 
+                response-body: [${JSON.stringify(response.data)}]
+                with status/statusText: ${response.status}/${
+                response.statusText
+            } \n`);
         }
 
         return response.data;
@@ -340,7 +364,10 @@ class API {
         const responseData = error.response && error.response.data;
         throw new Error(
             `${errorMessage}${
-                responseData && typeof responseData === "object"? `: ${JSON.stringify(responseData)}`: ""}`
+                responseData && typeof responseData === "object"
+                    ? `: ${JSON.stringify(responseData)}`
+                    : ""
+            }`
         );
     }
 }

--- a/src/api.js
+++ b/src/api.js
@@ -181,8 +181,8 @@ class API {
 
     async finishTestItem(projectName, testItemId, options) {
         if (this._debug == true) {
-            process.stdout;
-            write(`[${filename}] finishTestItem: [PUT] /${projectName}/item/${testItemId}
+            process.stdout
+                .write(`[${filename}] finishTestItem: [PUT] /${projectName}/item/${testItemId}
             Of launch: ${options.launchUuid}
             With options: ${JSON.stringify(options)}\n `);
         }
@@ -364,9 +364,7 @@ class API {
         const responseData = error.response && error.response.data;
         throw new Error(
             `${errorMessage}${
-                responseData && typeof responseData === "object"
-                    ? `: ${JSON.stringify(responseData)}`
-                    : ""
+                responseData && typeof responseData === "object" ? `: ${JSON.stringify(responseData)}` : ""
             }`
         );
     }

--- a/src/report-portal.js
+++ b/src/report-portal.js
@@ -34,9 +34,7 @@ class ReportPortal {
         this._completedLaunch = false;
         this.client = new RPClient(
             {
-                protocol: cliArguments.rprotocol
-                    ? cliArguments.rprotocol
-                    : "https",
+                protocol: cliArguments.rprotocol ? cliArguments.rprotocol : "https",
                 domain: cliArguments.rdomain,
                 apiPath: "/api/v1",
                 //synchronous api

--- a/src/report-portal.js
+++ b/src/report-portal.js
@@ -305,10 +305,15 @@ class ReportPortal {
     }
     //set status of a fixture based on Error existance in the queue
     async _checkFixtureStatus() {
-        if (this._queue[0] && this._queue[0].action === "error") {
-            return "failed";
-        }
-        return "passed";
+        try{
+            if(this._queue[0] && this._queue[0].action==='error'){
+              return "failed";
+            }
+          }
+          catch(error){
+            if (this._debug == true) process.stdout.write(`\n[${filename}] Error in getting Fixture status from queue\n`);
+          }
+          return "passed";
     }
 
     //Finishing a launch

--- a/src/report-portal.js
+++ b/src/report-portal.js
@@ -1,7 +1,11 @@
 const RPClient = require("./api");
+
 const cliArguments = require("cli-argument-parser").cliArguments;
+
 const { LMdebug, LogActions } = require("./log-appender");
+
 const path = require("path");
+
 const filename = path.basename(__filename);
 
 class ReportPortal {
@@ -14,8 +18,6 @@ class ReportPortal {
             throw new Error("Missing argument --rlaunch/--rlaunch-id");
         if (!cliArguments.rproject)
             throw new Error("Missing argument --rproject");
-
-       
         this.connected = true;
         this._itemsIds = []; //stack of parents
         this.launchName = cliArguments.rlaunch;
@@ -25,21 +27,25 @@ class ReportPortal {
             this._suiteStatus = "passed";
         }
         this._fixture = undefined;
-        this._debug = ( cliArguments.rdebug === "true")? true:false;
+        this._debug = cliArguments.rdebug === "true" ? true : false;
         this._queue = []; //msgs queue
         this._waitingForReply = false;
         this._testStatus = "passed";
         this._completedLaunch = false;
+        this.client = new RPClient(
+            {
+                protocol: cliArguments.rprotocol
+                    ? cliArguments.rprotocol
+                    : "https",
+                domain: cliArguments.rdomain,
+                apiPath: "/api/v1",
+                //synchronous api
+                token: cliArguments.rtoken,
+            },
+            this._debug
+        );
+    } //Verifying the connection to Report Portal
 
-        this.client = new RPClient({
-            protocol: cliArguments.rprotocol ? cliArguments.rprotocol : "https",
-            domain: cliArguments.rdomain,
-            apiPath: "/api/v1", //synchronous api
-            token: cliArguments.rtoken,
-        },this._debug);
-    }
-
-    //Verifying the connection to Report Portal
     async verifyConnection() {
         try {
             await this.client.checkConnect();
@@ -64,46 +70,58 @@ class ReportPortal {
                 description: `Running ${this.launchName} tests`,
             });
             this._completedLaunch = false;
-        } else this.launch = { id: cliArguments["rlaunch-id"] };
+        } else
+            this.launch = {
+                id: cliArguments["rlaunch-id"],
+            };
 
-    // Adding suite with the attributes
-    const launchAttributes = await this.client.getLaunchAttributes(this.projectName, this.launch.id);
-    const FFaddingLaunchInfo = false;
-    if (FFaddingLaunchInfo){
-        if(launchAttributes.length > 0 ){
-            const suiteDescription = `
-            ${launchAttributes.map(attr =>{
-              return `* ${attr.key}: ${attr.value} \n`;
+        // Adding suite with the attributes
+        const launchAttributes = await this.client.getLaunchAttributes(
+            this.projectName,
+            this.launch.id
+        );
+        const FFaddingLaunchInfo = false;
+
+        if (FFaddingLaunchInfo) {
+            if (launchAttributes.length > 0) {
+                const suiteDescription = `
+            ${launchAttributes.map((attr) => {
+                return `* ${attr.key}: ${attr.value} \n`;
             })}
-          `.replace(/\n,/g,"\n");
-      
-          const launchInfoSuite  = await this.client.createTestItem(this.projectName, {
-            launchUuid: this.launch.id,
-            name: "Launch Info:",
-            startTime: time,
-            description: suiteDescription,
-            type: "SUITE"
-          });
-      
-          await this.client.finishTestItem(this.projectName, launchInfoSuite.id, {
-            launchUuid: this.launch.id,
-            status: "passed",
-            endTime: time
-          });
-      
+          `.replace(/\n,/g, "\n");
+                const launchInfoSuite = await this.client.createTestItem(
+                    this.projectName,
+                    {
+                        launchUuid: this.launch.id,
+                        name: "Launch Info:",
+                        startTime: time,
+                        description: suiteDescription,
+                        type: "SUITE",
+                    }
+                );
+                await this.client.finishTestItem(
+                    this.projectName,
+                    launchInfoSuite.id,
+                    {
+                        launchUuid: this.launch.id,
+                        status: "passed",
+                        endTime: time,
+                    }
+                );
+            }
         }
-    }    
-    
-   
 
-        this._itemsIds.push({ type: "LAUNCH", id: this.launch.id });
+        this._itemsIds.push({
+            type: "LAUNCH",
+            id: this.launch.id,
+        });
+
         if (this._debug == true)
             process.stdout.write(
-                `[${filename}]startLaunch id:${this.launch.id}\n`
+                `\n[${filename}]startLaunch id:${this.launch.id}\n`
             );
         if (this.suiteName) await this._startSuite(this.suiteName, time);
     }
-
     /**
      * Creating a new suite
      * @param {*} name The name of the suite
@@ -117,11 +135,14 @@ class ReportPortal {
             type: "SUITE",
         });
         if (this.suite && this.suite.id) {
-            this._itemsIds.push({ type: "SUITE", id: this.suite.id });
+            this._itemsIds.push({
+                type: "SUITE",
+                id: this.suite.id,
+            });
         }
         if (this._debug == true)
             process.stdout.write(
-                `[${filename}]launch ${this.launch.id} startSuite ${this.suite.id}  \n`
+                `\n[${filename}]launch ${this.launch.id} startSuite ${this.suite.id}  \n`
             );
     }
 
@@ -147,14 +168,18 @@ class ReportPortal {
                     this.projectName,
                     options
                 );
-            this._itemsIds.push({ type: "FIXTURE", id: this._fixture.id });
+
+            this._itemsIds.push({
+                type: "FIXTURE",
+                id: this._fixture.id,
+            });
+
             if (this._debug == true)
                 process.stdout.write(
-                    `[${filename}] startFixturePreTest ${this._fixture.id} \n`
+                    `\n[${filename}] startFixturePreTest ${this._fixture.id} \n`
                 );
         }
     }
-
     /**
      * Starting a new test
      * @param {*} name The name of the test
@@ -190,11 +215,10 @@ class ReportPortal {
             });
             if (this._debug == true)
                 process.stdout.write(
-                    `[${filename}] startTest ${this.test.id} \n`
+                    `\n[${filename}] startTest ${this.test.id} \n`
                 );
         }
     }
-
     /**
      * Starting a new step
      * @param {*} name The name of the step
@@ -208,7 +232,6 @@ class ReportPortal {
             type: "STEP",
             hasStats: false,
         };
-
         const stepParent = this.getLastItem();
         if (stepParent) {
             let step = await this.client.createChildTestItem(
@@ -217,10 +240,14 @@ class ReportPortal {
                 options
             );
             if (step !== undefined && step.id !== undefined) {
-                this._itemsIds.push({ type: "STEP", id: step.id });
+                this._itemsIds.push({
+                    type: "STEP",
+                    id: step.id,
+                });
+
                 if (this._debug == true)
                     process.stdout.write(
-                        `[${filename}] startStep ${step.id}\n`
+                        `\n[${filename}] startStep ${step.id}\n`
                     );
             }
         }
@@ -232,7 +259,7 @@ class ReportPortal {
             if (lastItem.type == "STEP") {
                 if (this._debug == true)
                     process.stdout.write(
-                        `[${filename}] finish step. status: ${stepStatus}\n`
+                        `\n[${filename}] finish step. status: ${stepStatus}\n`
                     );
                 await this.client.finishTestItem(
                     this.projectName,
@@ -251,19 +278,21 @@ class ReportPortal {
     async _finishFixture(time) {
         //close all open steps if exist
         if (this._fixture) {
-            await this._finishNestedSteps("passed");
+            this.fxStatus = await this._checkFixtureStatus();
+            await this._finishNestedSteps(this.fxStatus);
             const lastItem = this.getLastItem();
+
             if (lastItem.type == "FIXTURE") {
                 if (this._debug == true)
                     process.stdout.write(
-                        `[${filename}] finish fixture ${lastItem.id} \n`
+                        `\n[${filename}] finish fixture ${lastItem.id} \n`
                     );
                 await this.client.finishTestItem(
                     this.projectName,
                     lastItem.id,
                     {
                         launchUuid: this.launch.id,
-                        status: "passed",
+                        status: this.fxStatus,
                         endTime: time,
                     }
                 );
@@ -271,6 +300,13 @@ class ReportPortal {
                 this._fixture = undefined;
             }
         }
+    }
+    //set status of a fixture based on Error existance in the queue
+    async _checkFixtureStatus() {
+        if (this._queue[0] && this._queue[0].action === "error") {
+            return "failed";
+        }
+        return "passed";
     }
 
     //Finishing a launch
@@ -286,7 +322,7 @@ class ReportPortal {
         if (this.launchName) {
             if (this._debug == true)
                 process.stdout.write(
-                    `[${filename}] finishLaunch. status: ${status}\n`
+                    `\n[${filename}] finishLaunch. status: ${status}\n`
                 );
             await this.client.finishLaunch(this.projectName, this.launch.id, {
                 endTime: time,
@@ -295,7 +331,6 @@ class ReportPortal {
         this._itemsIds = [];
         this._completedLaunch = true;
     }
-
     /**
      * Finishing a test
      * @param {*} testId The id of the test
@@ -312,7 +347,7 @@ class ReportPortal {
         if (item && item.isTest) {
             if (this._debug == true)
                 process.stdout.write(
-                    `[${filename}] finish test ${item.id}. status: ${this._testStatus}\n`
+                    `\n[${filename}] finish test ${item.id}. status: ${this._testStatus}\n`
                 );
             await this.client.finishTestItem(this.projectName, item.id, {
                 launchUuid: this.launch.id,
@@ -347,7 +382,7 @@ class ReportPortal {
         if (this._itemsIds[this._itemsIds.length - 1].type == "SUITE") {
             if (this._debug == true)
                 process.stdout.write(
-                    `[${filename}] finish suite. status: ${status}\n`
+                    `\n[${filename}] finish suite. status: ${status}\n`
                 );
             await this.client.finishTestItem(this.projectName, suiteId, {
                 launchUuid: this.launch.id,
@@ -359,7 +394,6 @@ class ReportPortal {
             this.suiteName = undefined;
         }
     }
-
     /**
      * Sending testing logs
      * @param {*} testId The id of the test
@@ -485,7 +519,7 @@ class ReportPortal {
                     break;
                 default:
                     process.stdout.write(
-                        `[${filename}]ERROR: unknown action type: ${actionType}\n`
+                        `\n[${filename}]ERROR: unknown action type: ${actionType}\n`
                     );
             }
             this._waitingForReply = false;

--- a/src/report-portal.js
+++ b/src/report-portal.js
@@ -223,6 +223,10 @@ class ReportPortal {
      */
 
     async _startStep(time, name = "'->") {
+        // Adding gaurd of the length of the group name (on overflow, it will break the launch report)
+        if (name.length > 120) {
+            name = name.substring(0, 120);
+        }
         const options = {
             launchUuid: this.launch.id,
             name: name,

--- a/src/reportportal-appender.js
+++ b/src/reportportal-appender.js
@@ -57,7 +57,7 @@ class ReportPortalAppender extends LogAppender {
     async startFixture(arg) {
         await this.reporter.appendAction(
             LogActions.START_FIXTURE,
-            `[before first Test] ${arg}`
+            `[Start Fixture (Before)] ${arg}`
         );
     }
 


### PR DESCRIPTION
Fixture Before:
added a check in _checkFixtureStatus instead of using "pass" for fixture and it child events always

Logs:
Refactored: sendLogWithFile - to print to debug logs as well
Aligned and formatted all logs at api and reportportal files for better plugin debugging

merged the 2 fixes that where stuck from the past, group name trunk and change the name of Before first test